### PR TITLE
mysql.sock symlink

### DIFF
--- a/mac
+++ b/mac
@@ -43,6 +43,8 @@ echo "Installing MySQL, our standard database server."
   unset TMPDIR
   mysql_install_db --verbose --user=`whoami` --basedir="$(brew --prefix mysql)" --datadir=/usr/local/var/mysql --tmpdir=/tmp
   mysql.server start
+  sudo mkdir /var/mysql
+  sudo ln -s /tmp/mysql.sock /var/mysql/mysql.sock
 
 echo "Installing a test phpinfo.php in the new DocumentRoot."
   [[ -d $HOME/htdocs ]] || {


### PR DESCRIPTION
not sure if this is the right place or right command, but after running and trying to get a local drupal going, i had to symlink to make sure the socket file was read. figured it wouldn't hurt to put it in the script (or maybe check for it)
